### PR TITLE
fix: wrong coordinates with translate3d

### DIFF
--- a/src/KnobArea.test.ts
+++ b/src/KnobArea.test.ts
@@ -10,6 +10,12 @@ interface Global {
 
 declare const global: Global
 
+// Mock getComputedStyle used in KnobArea.getComputedTransformXY
+global.window.getComputedStyle = (): CSSStyleDeclaration => {
+    const DivElement = mock<HTMLDivElement>()
+    return instance(DivElement).style
+}
+
 describe('class KnobArea', () => {
     const BodyClass = mock<HTMLBodyElement>()
     when(BodyClass.tagName).thenReturn('BODY')

--- a/stories/4.Layout.stories.tsx
+++ b/stories/4.Layout.stories.tsx
@@ -143,6 +143,88 @@ export function MultipleKnobsAndPositionsDemo(): JSX.Element {
                     }}
                 />
             </div>
+            <div>
+                <h1>CSS transform: translate, translate3d, scale</h1>
+                <div
+                    style={{
+                        position: 'relative',
+                        height: '520px',
+                        backgroundColor: '#d99',
+                    }}
+                >
+                    <PositionedKnob
+                        style={{
+                            position: 'absolute',
+                            top: '0',
+                            left: '0',
+                            transform: 'translate3d(0, 0, 0)',
+                        }}
+                    />
+                    <PositionedKnob
+                        style={{
+                            position: 'absolute',
+                            top: '0',
+                            left: '0',
+                            transform:
+                                'translate3d(5em, 260px, 50px) scale(0.5)',
+                        }}
+                    />
+                    <PositionedKnob
+                        style={{
+                            position: 'absolute',
+                            top: '0',
+                            left: '0',
+                            transform: 'translate3d(260px, 130px, 0)',
+                        }}
+                    />
+                    <div
+                        style={{
+                            position: 'absolute',
+                            left: 0,
+                            top: 0,
+                            transform: 'translate3d(480px, 0, 0)',
+                        }}
+                    >
+                        <PositionedKnob
+                            style={{
+                                position: 'absolute',
+                                top: '0',
+                                left: '0',
+                                transform: 'translate3d(0, 0, 0)',
+                            }}
+                        />
+                        <PositionedKnob
+                            style={{
+                                position: 'absolute',
+                                top: '0',
+                                left: '0',
+                                transform:
+                                    'translate3d(5em, 260px, 50px) scale(0.7)',
+                            }}
+                        />
+                        <PositionedKnob
+                            style={{
+                                position: 'absolute',
+                                top: '0',
+                                left: '0',
+                                transform: 'translate3d(260px, 130px, 0)',
+                            }}
+                        />
+                    </div>
+                </div>
+                <div
+                    style={{
+                        color: 'red',
+                        fontSize: '22px',
+                        padding: '10px',
+                        margin: '10px',
+                        border: '1px solid red',
+                    }}
+                >
+                    If parent container uses CSS transform scale, Knob diameter
+                    is not calculated properly. Known issue!
+                </div>
+            </div>
             <PositionedKnob
                 style={{
                     position: 'relative',


### PR DESCRIPTION
CSS translate3d offset was not included when calculating element position